### PR TITLE
Fix try catch added for crashes on jsdev pause

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/react/JsDevReloadHandler.java
@@ -52,7 +52,11 @@ public class JsDevReloadHandler extends JsDevReloadHandlerFacade {
 	}
 
 	public void onActivityPaused(Activity activity) {
-		activity.unregisterReceiver(reloadReceiver);
+		try {
+			activity.unregisterReceiver(reloadReceiver);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 	public boolean onKeyUp(int keyCode) {


### PR DESCRIPTION
https://console.firebase.google.com/project/dream11-sportsguru/crashlytics/app/android:com.dream11sportsguru/issues/5c3dbd18f8b88c29635608e7?time=last-seven-days&sessionEventKey=6003B58C033500012D0CA3314647F571_1497021310441686910

Crash issue solved with try catch as JsDev should not be running in Prod mode anyway

<img width="1520" alt="Screenshot 2021-01-17 at 10 21 29 AM" src="https://user-images.githubusercontent.com/60878859/104831329-c6090b00-58ad-11eb-94b1-393fd60ce41e.png">
