### PR TITLE
fix(NavigationActivity.java): native backpress crash in PIP edge case catched

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/NavigationActivity.java
@@ -156,7 +156,11 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         if (navigator.shouldSwitchToPIPonBackPress()) {
             navigator.updatePIPState(PIPStates.MOUNT_START);
         } else if (!navigator.handleBack(new CommandListenerAdapter())) {
-            super.onBackPressed();
+            try {
+                super.onBackPressed();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/dream11-sportsguru/crashlytics/app/android:com.dream11sportsguru/issues/feec3e44b761954818c62470d027ed22?time=last-seven-days&sessionEventKey=606AA79D039800010BD13C3237D8488F_1525995552453212892&versions=3.43.0%20(4200359);3.43.0%20(4200524);3.43.0%20(4200523)

This issue has 17775 crash events affecting 12164 users

Above crash solved

… catched